### PR TITLE
Including year in date

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -2920,7 +2920,7 @@ end
 
 function bepgp:getServerTime()
   local epoch = GetServerTime()
-  local d = date("%b-%d",epoch)
+  local d = date("%Y-%m-%d",epoch)
   local t = date("%H:%M:%S",epoch)
   local timestamp = string.format("%s %s",d,t)
   return epoch, timestamp


### PR DESCRIPTION
Since ClassicTBC will span more than one year logs should contain the year. Changed date format to ISO 8601